### PR TITLE
Add netcdf

### DIFF
--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -7,8 +7,30 @@ RUN apt-get -y update
 RUN apt-get -y install wget time nano vim emacs
 
 # Libraries that octopus needs
+RUN apt-get -y install autoconf libtool
 RUN apt-get -y install git gcc g++ gfortran libxc-dev libblas-dev liblapack-dev libgsl-dev libfftw3-dev build-essential procps
-# autoconf?
+# Optional dependencies
+RUN apt-get -y install libnetcdff-dev libetsf-io-dev libspfft-dev libnlopt-dev libyaml-dev libgmp-dev likwid
+# Not recognised in `config.log`: libfm-dev
+
+# Other missing dependencies:
+# root@3c84fb9cc693:/opt/octopus-11.1# less config.log | grep WARNIN
+# root@ab9a50547c08:/opt/octopus-11.1# less config.log | grep WARNI
+# configure:12023: WARNING: Could not find libvdwxc library.
+# configure:13584: WARNING: Could not find PFFT library.
+# configure:13811: WARNING: Could not find PNFFT library.
+# configure:14326: WARNING: Could not find BerkeleyGW library.
+# configure:14420: WARNING: Could not find SPARSKIT library.
+# configure:15035: WARNING: elpa library is not used because scalapack is not found which is a prerequisite for elpa
+# configure:15105: WARNING: Could not find Libfm library.
+# configure:15306: WARNING: Could not find Futile library.
+# configure:15403: WARNING: Could not find PSolver library.
+# configure:15544: WARNING: MPFR not found (a CGAL dependency)
+# configure:16132: WARNING: Could not find ISF library.
+# configure:16301: WARNING: Could not find the poke library
+# configure:16587: WARNING: Octopus will be compiled without PARMETIS support
+# configure:16804: WARNING: Could not find DFTBPLUS library.
+
 
 WORKDIR /opt
 RUN wget -O oct.tar.gz http://octopus-code.org/down.php?file=11.1/octopus-11.1.tar.gz
@@ -17,8 +39,8 @@ RUN tar xfvz oct.tar.gz
 RUN pwd
 RUN ls -l 
 WORKDIR /opt/octopus-11.1
-# autoreconf -i
-RUN ./configure
+RUN autoreconf -i
+RUN ./configure 
 RUN make
 RUN make install
 # The next command returns an error code as some tests fail

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then activate spack:
 
 - `source spack/share/spack/setup-env.sh`
 
-Then compile octopus (this could take some time) with netcdf support:
+Then compile octopus (this could take some time). For this example, we want to include netcdf support:
 
 - `spack install octopus +netcdf`
 


### PR DESCRIPTION
- show how to include netcdf in spack version
- also install some of the optional dependencies in the Debian Docker container (to demo direct installation on Debian-based OS).