### PR TITLE
Add Python bindings (for ELPA); Input from Heiko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,12 @@ RUN $SPACK --version
 
 # build octopus
 COPY spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/octopus
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf
+# RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf
+# RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf
+
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf+parmetis+arpack+cgal+pfft+poke+python+likwid+libyaml+elpa+nlopt
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf+parmetis+arpack+cgal+pfft+poke+python+likwid+libyaml+elpa+nlopt
+
 
 CMD /bin/bash -l
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ COPY spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/octopus
 # RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf
 # RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf
 
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf+parmetis+arpack+cgal+pfft+poke+python+likwid+libyaml+elpa+nlopt
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf+parmetis+arpack+cgal+pfft+poke+python+likwid+libyaml+elpa+nlopt
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt
 
 
 CMD /bin/bash -l

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Compile Octopus on Linux with Spack. Spack's preferred option is 11.1 at the
 moment (if you follow `Compilation of Octopus using Spack`_):
 
 |spack-v0.16.2-oct-11.1| Spack release 0.16.2, preferred version of Octopus
+
 |spack-v0.16.3-oct-11.1| Spack release 0.16.3, preferred version of Octopus
 
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -47,7 +47,7 @@ class Octopus(Package, CudaPackage):
     variant('pfft', default=False,
             description='Compile with PFFT')
     variant('poke', default=False,
-            description='Compile with poke')
+            description='Compile with poke (not available in spack yet)')
     variant('python', default=True,
             description='Activates Python support')
     variant('likwid', default=False,

--- a/spack/package.py
+++ b/spack/package.py
@@ -48,6 +48,8 @@ class Octopus(Package, CudaPackage):
             description='Compile with PFFT')
     variant('poke', default=False,
             description='Compile with poke')
+    variant('python', default=True,
+            description='Activates Python support')
     variant('likwid', default=False,
             description='Compile with likwid')
     variant('libvdwxc', default=False,
@@ -79,6 +81,8 @@ class Octopus(Package, CudaPackage):
     depends_on('fftw-api@3:', when='@10:')
     depends_on('metis@5:', when='+metis')
     depends_on('parmetis', when='+parmetis')
+    depends_on('py-numpy', when='+python')
+    depends_on('py-mpi4py', when='+python')
     depends_on('scalapack', when='+scalapack')
     depends_on('netcdf-fortran', when='+netcdf')
     depends_on('arpack-ng', when='+arpack')
@@ -201,6 +205,9 @@ class Octopus(Package, CudaPackage):
             args.extend([
                 '--enable-cuda'
             ])
+
+        if '+python' in spec:
+            args.extend('--enable-python')
 
         # --with-etsf-io-prefix=
         # --with-sparskit=${prefix}/lib/libskit.a


### PR DESCRIPTION
Modified spack package.py for ELPA
----------------------------------

<pre>
diff --git i/var/spack/repos/builtin/packages/elpa/package.py w/var/spack/repos/builtin/packages/elpa/package.py
index 6ab9ba299a..40c12e6000 100644
--- i/var/spack/repos/builtin/packages/elpa/package.py
+++ w/var/spack/repos/builtin/packages/elpa/package.py
@@ -31,11 +31,14 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):

    variant('openmp', default=True, description='Activates OpenMP support')
    variant('mpi', default=True, description='Activates MPI support')
+    variant('python', default=True, description='Activates Python support')

    depends_on('blas')
    depends_on('lapack')
    depends_on('mpi', when='+mpi')
    depends_on('scalapack', when='+mpi')
+    depends_on('py-numpy', when='+python')
+    depends_on('py-mpi4py', when='+python')
    depends_on('rocblas', when='+rocm')
    depends_on('libtool', type='build')
    depends_on('python@:2', type='build', when='@:2020.05.001')
@@ -159,6 +162,9 @@ def configure_args(self):
                'SCALAPACK_LDFLAGS={0}'.format(spec['scalapack'].libs.joined())
            ]

+        if '+python' in self.spec:
+            options.append('--enable-python')
+
        options.append('--disable-silent-rules')

        return options
</pre>