### PR TITLE
attempt to include spack develop into main

### DIFF
--- a/.github/workflows/spack-develop.yml
+++ b/.github/workflows/spack-develop.yml
@@ -1,0 +1,19 @@
+name: spack-develop
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: make spack-develop
+      


### PR DESCRIPTION
- historically, this used to fail because of the
  new dependecy resolution engine. as this has been fixed now,
  it seems more stable