### PR TITLE
Upgrade to octopus 12 spack package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Status
 ------
 
 
-Compile Octopus on Linux with Spack. Spack's preferred option is 11.4 at the
+Compile Octopus on Linux with Spack. Spack's preferred option is 12.0 at the
 moment (if you follow `Compilation of Octopus using Spack`_):
 
 |spack-latest-octopus-stable| Spack latest release, preferred version of Octopus; Compiled every Monday 2PM CET
@@ -60,7 +60,7 @@ want to include netcdf support:
 
 -  ``spack install octopus +netcdf``
 
-Ideally, there are no errors. This should install Octopus 11.4
+Ideally, there are no errors. This should install Octopus 12.0
 
 There are further *variants* you can install. For example:
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -20,6 +20,7 @@ class Octopus(Package, CudaPackage):
 
     maintainers = ["fangohr", "RemiLacroix-IDRIS"]
 
+    version("12.0", sha256="70beaf08573d394a766f10346a708219b355ad725642126065d12596afbc0dcc")
     version("11.4", sha256="73bb872bff8165ddd8efc5b891f767cb3fe575b5a4b518416c834450a4492da7")
     version("11.3", sha256="0c98417071b5e38ba6cbdd409adf917837c387a010e321c0a7f94d9bd9478930")
     version("11.1", sha256="d943cc2419ca409dda7459b7622987029f2af89984d0d5f39a6b464c3fc266da")


### PR DESCRIPTION
Upgrade spack's `octopus/package.py` to octopus version 12.0 (in this repository).

Preparation for merge request to spack upstream at later point.