### PR TITLE
AutotoolsPackage implementation with no autoreconf method

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -10,7 +10,8 @@ import llnl.util.tty as tty
 from spack.package import *
 import llnl.util.filesystem as fs
 
-class Octopus(Package, CudaPackage):
+
+class Octopus(AutotoolsPackage, CudaPackage):
     """A real-space finite-difference (time-dependent) density-functional
     theory code."""
 
@@ -55,10 +56,10 @@ class Octopus(Package, CudaPackage):
     variant("nlopt", default=False, description="Compile with nlopt")
     variant("debug", default=False, description="Compile with debug flags")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    depends_on("autoconf", type="build", when="@develop")
+    depends_on("automake", type="build", when="@develop")
+    depends_on("libtool", type="build", when="@develop")
+    depends_on("m4", type="build", when="@develop")
 
     depends_on("blas")
     depends_on("gsl@1.9:")
@@ -90,7 +91,9 @@ class Octopus(Package, CudaPackage):
     # TODO: etsf-io, sparskit,
     # feast, libfm, pfft, isf, pnfft, poke
 
-    def install(self, spec, prefix):
+
+    def configure_args(self):
+        spec = self.spec
         lapack = spec["lapack"].libs
         blas = spec["blas"].libs
         args = []
@@ -211,12 +214,7 @@ class Octopus(Package, CudaPackage):
                 args.append(fcflags)
                 args.append(fflags)
 
-        autoreconf("-i")
-        configure(*args)
-        make()
-        # short tests take forever...
-        # make('check-short')
-        make("install")
+        return args
 
     @run_after("install")
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
Refactored to use AutotoolsPackage. Removed autoreconf method and added when="@develop" to the autoconf, automake, libtool and m4 dependencies