### PR TITLE
rename "develop" to "main" branch on Octopus git repository 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ moment (if you follow `Compilation of Octopus using Spack`_):
 
 |spack-latest-octopus-stable| Spack latest release, preferred version of Octopus; run every month
 
-|spack-latest-octopus-develop| Spack latest release, development version of Octopus
+|spack-latest-octopus-develop| Spack latest release, development version of Octopus (branch "main")
 
 
 |spack-develop-octopus-stable| Spack develop version, preferred version of Octopus; run every week

--- a/spack/package.py
+++ b/spack/package.py
@@ -36,7 +36,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     version("6.0", sha256="4a802ee86c1e06846aa7fa317bd2216c6170871632c9e03d020d7970a08a8198")
     version("5.0.1", sha256="3423049729e03f25512b1b315d9d62691cd0a6bd2722c7373a61d51bfbee14e0")
 
-    version("develop", branch="develop")
+    version("develop", branch="main")  # Octopus development branch is called "main" since Q3 2022
 
     variant("mpi", default=True, description="Build with MPI support")
     variant("scalapack", default=False, description="Compile with Scalapack")


### PR DESCRIPTION
The octopus development took place on the 'develop' branch in the past,
and has been renamed to 'main' in Q3 2022.

This change should reflect that.