### PR TITLE
Remove redundant FFLAGS

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -230,14 +230,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
             # warning and build sucessfully
 
             fcflags = "FCFLAGS=-O2 -ffree-line-length-none"
-            fflags = "FFLAGS=O2 -ffree-line-length-none"
             if spec.satisfies("%gcc@10:"):
                 gcc10_extra = "-fallow-argument-mismatch -fallow-invalid-boz"
                 args.append(fcflags + " " + gcc10_extra)
-                args.append(fflags + " " + gcc10_extra)
             else:
                 args.append(fcflags)
-                args.append(fflags)
 
         return args
 


### PR DESCRIPTION
Henning has found in his experiments that the octopus configure script dosent use the FFLAGS at all which we are setting,
we can hence remove it from here to reduce clutter.
For eg  the sample output from octopus dosent include a section on FFLAGS:
```shell
Version                : 12.1
Commit                 :
Build time             : Mon Feb 27 21:57:54 CET 2023
Configuration options  : maxdim3 openmp mpi sse2 avx libxc5 libxc_fxc
Optional libraries     : cgal metis netcdf parmetis pfft nlopt
Architecture           : x86_64
C compiler             : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/opt/spack/linux-debian11-sandybridge/gcc-11.3.0/openmpi-4.1.4-4lehnqllo3r6t45ix2wrdcew6lfwsdgw/bin/mpicc (/opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/gcc)
C compiler flags       : -g -O2
C++ compiler           : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/g++
C++ compiler flags     : -g -O2
Fortran compiler       : /opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/opt/spack/linux-debian11-sandybridge/gcc-11.3.0/openmpi-4.1.4-4lehnqllo3r6t45ix2wrdcew6lfwsdgw/bin/mpif90 (/opt_mpsd/linux-debian11/dev-23a/sandybridge/spack/lib/spack/env/gcc/gfor
Fortran compiler flags : -O2 -ffree-line-length-none -fallow-argument-mismatch -fallow-invalid-boz -fopenmp
```
This MR fixes #65 