### PR TITLE
Add and test pnfft variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,9 +88,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt~debug~cuda~metis~scalapack  && \
+      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt~debug~cuda~metis~scalapack  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt~debug~cuda~metis~scalapack  && \
+      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt~debug~cuda~metis~scalapack  && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/spack/package.py
+++ b/spack/package.py
@@ -82,6 +82,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
         depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
         depends_on("fftw-api@3:+openmp~mpi", when="@10:")
@@ -100,7 +101,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("likwid", when="+likwid")
     depends_on("libyaml", when="+libyaml")
     depends_on("nlopt", when="+nlopt")
-    depends_on("pfft", when="+pfft")
+    depends_on("pnfft", when="+pnfft")
 
     # optional dependencies:
     # TODO: etsf-io, sparskit,

--- a/spack/package.py
+++ b/spack/package.py
@@ -47,6 +47,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("arpack", default=False, description="Compile with ARPACK")
     variant("cgal", default=False, description="Compile with CGAL library support")
     variant("pfft", default=False, when="+mpi", description="Compile with PFFT")
+    variant("pnfft", default=False, when="+pfft", description="Compile with PNFFT")
     # poke here refers to https://gitlab.e-cam2020.eu/esl/poke
     # variant('poke', default=False,
     #         description='Compile with poke (not available in spack yet)')
@@ -81,7 +82,6 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
         depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
-
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
         depends_on("fftw-api@3:+openmp~mpi", when="@10:")
@@ -100,6 +100,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("likwid", when="+likwid")
     depends_on("libyaml", when="+libyaml")
     depends_on("nlopt", when="+nlopt")
+    depends_on("pfft", when="+pfft")
 
     # optional dependencies:
     # TODO: etsf-io, sparskit,
@@ -207,6 +208,9 @@ class Octopus(AutotoolsPackage, CudaPackage):
         # --with-etsf-io-prefix=
         # --with-sparskit=${prefix}/lib/libskit.a
         # --with-pfft-prefix=${prefix} --with-mpifftw-prefix=${prefix}
+        if "+pnfft" in spec:
+            args.append("--with-pnfft-prefix=%s" % spec["pnfft"].prefix)
+
         # --with-berkeleygw-prefix=${prefix}
 
         # When preprocessor expands macros (i.e. CFLAGS) defined as quoted


### PR DESCRIPTION
This MR fixes #67 partially .
PNFFT requires PFFT which is useful only when MPI variant is used.