### PR TITLE
Fix scalapack: choose netlib-scalapack@2.1.0 as the provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-serial && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis && \
+      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis && \
+      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -88,9 +88,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis  && \
+      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis  && \
+      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis  && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-serial && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -88,9 +88,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+scalapack+elpa+nlopt+etsf-io+sparskit+berkeleygw~debug~cuda~metis  && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/spack/package.py
+++ b/spack/package.py
@@ -192,8 +192,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         if "+scalapack" in spec:
             args.extend(
                 [
-                    "--with-blacs=%s" % spec["scalapack"].libs,
-                    "--with-scalapack=%s" % spec["scalapack"].libs,
+                    "--with-blacs=-L%s -lscalapack" % spec["scalapack"].libs,
+                    "--with-scalapack=-L%s -lscalapack" % spec["scalapack"].libs,
                 ]
             )
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -101,7 +101,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("py-mpi4py", when="+python")
     depends_on("metis@5:+int64", when="+metis")
     depends_on("parmetis+int64", when="+parmetis")
-    depends_on("netlib-scalapack", when="+scalapack")
+    depends_on("netlib-scalapack@2.1.0", when="+scalapack")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
     depends_on("nfft@3.2.4", when="+nfft")

--- a/spack/package.py
+++ b/spack/package.py
@@ -101,7 +101,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("py-mpi4py", when="+python")
     depends_on("metis@5:+int64", when="+metis")
     depends_on("parmetis+int64", when="+parmetis")
-    depends_on("scalapack", when="+scalapack")
+    depends_on("netlib-scalapack", when="+scalapack")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
     depends_on("nfft@3.2.4", when="+nfft")


### PR DESCRIPTION
This MR sets the dependency  `scalapack` to `netlib-scalapack`.
Fixes #83 
 `scalapack` in spack is a virtual dependency provided by the following packages:
 ```shell
$ spack providers scalapack
scalapack:
amdscalapack  cray-libsci  fujitsu-ssl2  intel-mkl  intel-oneapi-mkl  intel-parallel-studio  netlib-scalapack
```
Octopus has been tested only with netlib-scalapack@2.1.0
