### PR TITLE
Add flavours as variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-serial && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      spack spec octopus@${OCT_VERSION} flavour=full_serial~mpi~debug~cuda~metis && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      spack add octopus@${OCT_VERSION}  flavour=full_serial~mpi~debug~cuda~metis  && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -88,9 +88,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      spack spec octopus@${OCT_VERSION} +flavour=full_mpi~debug~cuda~metis~scalapack  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      spack add octopus@${OCT_VERSION} +flavour=full_mpi~debug~cuda~metis~scalapack && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-serial && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} flavour=full_serial~mpi~debug~cuda~metis && \
+      spack spec octopus@${OCT_VERSION} flavour=full_serial ~mpi~debug~cuda~metis && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION}  flavour=full_serial~mpi~debug~cuda~metis  && \
+      spack add octopus@${OCT_VERSION}  flavour=full_serial ~mpi~debug~cuda~metis  && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -88,9 +88,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +flavour=full_mpi~debug~cuda~metis~scalapack  && \
+      spack spec octopus@${OCT_VERSION} +flavour=full_mpi ~debug~cuda~metis~scalapack  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +flavour=full_mpi~debug~cuda~metis~scalapack && \
+      spack add octopus@${OCT_VERSION} +flavour=full_mpi ~debug~cuda~metis~scalapack && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/spack/package.py
+++ b/spack/package.py
@@ -78,14 +78,10 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("debug", default=False, description="Compile with debug flags")
     # set a variant to quickly select a predefined set of optional dependencies
     variant(
-        'flavor',
-        values=(
-            'minimal',
-            'full_serial',
-            'full_mpi',
-        ),
+        "flavor",
+        values=("minimal", "full_serial", "full_mpi"),
         default=False,
-        description='Compile with a predefined set of optional dependencies',
+        description="Compile with a predefined set of optional dependencies",
     )
 
     depends_on("autoconf", type="build", when="@develop")

--- a/spack/package.py
+++ b/spack/package.py
@@ -78,7 +78,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("debug", default=False, description="Compile with debug flags")
     # set a variant to quickly select a predefined set of optional dependencies
     variant(
-        "flavor",
+        "flavour",
         values=("minimal", "full_serial", "full_mpi"),
         default=False,
         description="Compile with a predefined set of optional dependencies",
@@ -133,11 +133,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("pnfft", when="+pnfft")
     depends_on("nlopt", when="+nlopt")
 
-    # Define the dependencies for the flavors
-    with when("flavor=minimal"):
+    # Define the dependencies for the flavours
+    with when("flavour=minimal"):
         depends_on("cgal")
 
-    with when("flavor=full_serial" or "flavor=full_mpi"):
+    with when("flavour=full_serial" or "flavour=full_mpi"):
         # list all the dependencies
         # that are independent of the parallelism
         depends_on("cgal")
@@ -149,13 +149,13 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("sparskit")
         depends_on("nfft@3.2.4")
 
-    with when("flavor=full_serial"):
+    with when("flavour=full_serial"):
         # list all other serial dependencies
         depends_on("netcdf-fortran ^netcdf-c~~mpi")
         depends_on("arpack-ng~mpi")
         depends_on("berkeleygw@2.1~mpi")
 
-    with when("flavor=full_mpi"):
+    with when("flavour=full_mpi"):
         # list all other parallel dependencies
         depends_on("mpi")
         depends_on("netcdf-fortran ^netcdf-c+mpi")

--- a/spack/package.py
+++ b/spack/package.py
@@ -76,6 +76,17 @@ class Octopus(AutotoolsPackage, CudaPackage):
         description="Compile with PNFFT - Parallel Nonequispaced FFT library",
     )
     variant("debug", default=False, description="Compile with debug flags")
+    # set a variant to quickly select a predefined set of optional dependencies
+    variant(
+        'flavor',
+        values=(
+            'minimal',
+            'full_serial',
+            'full_mpi',
+        ),
+        default=False,
+        description='Compile with a predefined set of optional dependencies',
+    )
 
     depends_on("autoconf", type="build", when="@develop")
     depends_on("automake", type="build", when="@develop")
@@ -125,6 +136,40 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("libyaml", when="+libyaml")
     depends_on("pnfft", when="+pnfft")
     depends_on("nlopt", when="+nlopt")
+
+    # Define the dependencies for the flavors
+    with when("flavor=minimal"):
+        depends_on("cgal")
+
+    with when("flavor=full_serial" or "flavor=full_mpi"):
+        # list all the dependencies
+        # that are independent of the parallelism
+        depends_on("cgal")
+        depends_on("python")
+        depends_on("likwid")
+        depends_on("libyaml")
+        depends_on("nlopt")
+        depends_on("etsf-io")
+        depends_on("sparskit")
+        depends_on("nfft@3.2.4")
+
+    with when("flavor=full_serial"):
+        # list all other serial dependencies
+        depends_on("netcdf-fortran ^netcdf-c~~mpi")
+        depends_on("arpack-ng~mpi")
+        depends_on("berkeleygw@2.1~mpi")
+
+    with when("flavor=full_mpi"):
+        # list all other parallel dependencies
+        depends_on("mpi")
+        depends_on("netcdf-fortran ^netcdf-c+mpi")
+        depends_on("arpack-ng+mpi")
+        depends_on("berkeleygw@2.1+mpi")
+        depends_on("scalapack")
+        depends_on("pfft")
+        depends_on("pnfft")
+        depends_on("libvdwxc+mpi")
+        depends_on("elpa+mpi")
 
     # optional dependencies:
     # TODO: etsf-io, sparskit,


### PR DESCRIPTION
This MR tries to add `metavariants` to define a group of optional dependencies in order to give users an easy way to define "frequently used together dependencies" quickly.
for eg:
```shell
spack install octopus +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack 
```
becomes
```shell
spack install octopus +flavour=full_mpi~debug~cuda~metis~scalapac
```

We could base these flavours based on the EasyBuild package sets that octopus developers use if needed.
