### PR TITLE
Disable gdlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN apt-get install -y --no-install-recommends \
               vim \
            && rm -rf /var/lib/apt/lists/*
 
+# install packages the are not needed
+# but are installed only to test the --disable-package
+# argument of autotools package
+
+RUN apt-get install -y --no-install-recommends \
+             libgd-dev
+
 # load spack environment on login
 RUN echo "source $SPACK_ROOT/share/spack/setup-env.sh" \
            > /etc/profile.d/spack.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,6 @@ RUN apt-get install -y --no-install-recommends \
               vim \
            && rm -rf /var/lib/apt/lists/*
 
-# install packages the are not needed
-# but are installed only to test the --disable-package
-# argument of autotools package
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-             libgd-dev \
-             && rm -rf /var/lib/apt/lists/*
 
 # load spack environment on login
 RUN echo "source $SPACK_ROOT/share/spack/setup-env.sh" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,9 @@ RUN apt-get install -y --no-install-recommends \
 # but are installed only to test the --disable-package
 # argument of autotools package
 
-RUN apt-get install -y --no-install-recommends \
-             libgd-dev
+RUN apt-get update && apt-get install -y --no-install-recommends \
+             libgd-dev \
+             && rm -rf /var/lib/apt/lists/*
 
 # load spack environment on login
 RUN echo "source $SPACK_ROOT/share/spack/setup-env.sh" \

--- a/spack/package.py
+++ b/spack/package.py
@@ -297,7 +297,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append(f"{cflags} {gcc10_extra}")
 
         # Disable flags
-
+        #
         # disable gdlib explicitly to avoid
         # autotools picking gdlib up from the system
         args.append("--disable-gdlib")

--- a/spack/package.py
+++ b/spack/package.py
@@ -299,7 +299,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         # Disable flags
 
         # disable gdlib explicitly to avoid
-        # autotools picking it up gdlib from the system
+        # autotools picking gdlib up from the system
         args.append("--disable-gdlib")
 
         return args

--- a/spack/package.py
+++ b/spack/package.py
@@ -296,6 +296,12 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append(f"{cxxflags} {gcc10_extra}")
             args.append(f"{cflags} {gcc10_extra}")
 
+        # Disable flags
+
+        # disable gdlib explicitly to avoid
+        # autotools picking it up gdlib from the system
+        args.append("--disable-gdlib")
+
         return args
 
     @run_after("install")


### PR DESCRIPTION
We want to explicitly disable gdlib in order to avoid auto tools from picking it up from the system.