### PR TITLE
Reformulate dependencies

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -99,7 +99,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("libvdwxc+mpi", when="+libvdwxc")
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
-        depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+        depends_on("netcdf-fortran", when="+netcdf")
+        depends_on("netcdf-c+mpi", when="+netcdf")
         depends_on("berkeleygw@2.1+mpi", when="+berkeleygw")
 
     with when("~mpi"):  # list all the serial dependencies
@@ -108,7 +109,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("libvdwxc~mpi", when="+libvdwxc")
         depends_on("arpack-ng~mpi", when="+arpack")
         depends_on("elpa~mpi", when="+elpa")
-        depends_on("netcdf-fortran ^netcdf-c~~mpi", when="+netcdf")
+        depends_on("netcdf-fortran", when="+netcdf")
+        depends_on("netcdf-c~~mpi", when="+netcdf")
         depends_on("berkeleygw@2.1~mpi", when="+berkeleygw")
 
     depends_on("etsf-io", when="+etsf-io")


### PR DESCRIPTION
The old version seems to stun the concretizer (see https://github.com/fangohr/octopus-in-spack/issues/96)