### PR TITLE
Update BerkeleyGW dependency version in Octopus package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:bullseye
 # # (for example docker build --build-arg SPACK_VERSION=v0.16.2)
 ARG SPACK_VERSION=develop
 ARG OCT_VERSION=13.0
-ARG BER_VER=""
+ARG BERKELEYGW_VER=""
 RUN echo "Building with spack version ${SPACK_VERSION}"
 
 # Any extra packages to be installed in the host
@@ -72,9 +72,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
       # see https://github.com/spack/spack/issues/43122
       # TODO: remove the version number when the issue is resolved
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
+      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BERKELEYGW_VER} && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
+      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BERKELEYGW_VER} && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -92,9 +92,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER}  && \
+      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BERKELEYGW_VER}  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER} && \
+      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BERKELEYGW_VER} && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM debian:bullseye
 # # (for example docker build --build-arg SPACK_VERSION=v0.16.2)
 ARG SPACK_VERSION=develop
 ARG OCT_VERSION=13.0
+ARG BER_VER=""
 RUN echo "Building with spack version ${SPACK_VERSION}"
 
 # Any extra packages to be installed in the host
@@ -71,7 +72,6 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
       # see https://github.com/spack/spack/issues/43122
       # TODO: remove the version number when the issue is resolved
-      [[ "$OCT_VERSION" == "develop" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
       spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
       # run the spack installation (adding it to the environment):
       spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
@@ -92,7 +92,6 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      [[ "$OCT_VERSION" == "develop" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
       spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER}  && \
       # run the spack installation (adding it to the environment):
       spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
       # see https://github.com/spack/spack/issues/43122
       # TODO: remove the version number when the issue is resolved
-      [[ "$OCT_VERSION" == "13.0" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
+      [[ "$OCT_VERSION" == "develop" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
       spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
       # run the spack installation (adding it to the environment):
       spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
@@ -92,7 +92,7 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      [[ "$OCT_VERSION" == "13.0" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
+      [[ "$OCT_VERSION" == "develop" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
       spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER}  && \
       # run the spack installation (adding it to the environment):
       spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,13 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-serial && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
+      # see https://github.com/spack/spack/issues/43122
+      # TODO: remove the version number when the issue is resolved
+
+      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw@3.0.1 && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis && \
+      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw@3.0.1 && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,10 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
       # see https://github.com/spack/spack/issues/43122
       # TODO: remove the version number when the issue is resolved
-
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw@3.0.1 && \
+      [[ "$OCT_VERSION" == "13.0" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
+      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw@3.0.1 && \
+      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BER_VER} && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_serial octopus && \
@@ -92,9 +92,10 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env create octopus-mpi && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      [[ "$OCT_VERSION" == "13.0" ]] && export BER_VER="@3.0.1" || export BER_VER="" && \
+      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER}  && \
       # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack  && \
+      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BER_VER} && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias test_MPI octopus && \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ spack-develop:
 
 # Using most recent spack version with most recent version of octopus
 spack-develop-octopus-develop:
-	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg OCT_VERSION=develop  --build-arg BER_VER="@3.0.1" -t octopus-spack .
+	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg OCT_VERSION=develop  --build-arg BERKELEYGW_VER="@3.0.1" -t octopus-spack .
 
 
 # use particular versions of spack (these are not in the CI as older version of
@@ -15,7 +15,7 @@ spack-latest:
 	docker build -f Dockerfile --build-arg SPACK_VERSION=releases/latest -t octopus-spack .
 
 spack-latest-octopus-develop:
-	docker build -f Dockerfile --build-arg SPACK_VERSION=releases/latest --build-arg OCT_VERSION=develop -t octopus-spack .
+	docker build -f Dockerfile --build-arg SPACK_VERSION=releases/latest --build-arg OCT_VERSION=develop --build-arg BERKELEYGW_VER="@3.0.1" -t octopus-spack .
 
 
 run-spack:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ spack-develop:
 
 # Using most recent spack version with most recent version of octopus
 spack-develop-octopus-develop:
-	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg OCT_VERSION=develop -t octopus-spack .
+	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg OCT_VERSION=develop  --build-arg BER_VER="@3.0.1" -t octopus-spack .
 
 
 # use particular versions of spack (these are not in the CI as older version of
@@ -19,9 +19,9 @@ spack-latest-octopus-develop:
 
 
 run-spack:
-	docker run --rm -ti -v $PWD:/io octopus-spack 
+	docker run --rm -ti -v $PWD:/io octopus-spack
 
-.PHONY: spack-develop spack-develop-octopus-develop spack-latest spack-latest-octopus-develop spack-latest run-spack 
+.PHONY: spack-develop spack-develop-octopus-develop spack-latest spack-latest-octopus-develop spack-latest run-spack
 
 diff:
 	@echo "Compare (diff) spack/package.py with current package.py from spack develop"

--- a/spack/package.py
+++ b/spack/package.py
@@ -106,8 +106,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
             # only BerkeleyGW 3 is supported from version 14
             # see https://gitlab.com/octopus-code/octopus/-/merge_requests/2257
             # BerkeleyGW 2.1 is the last supported version until octopus@14
-            depends_on("berkeleygw@3:+mpi", when="@:13")
-            depends_on("berkeleygw@2.1+mpi", when="@14:")
+            depends_on("berkeleygw@3:+mpi", when="@14:")
+            depends_on("berkeleygw@2.1+mpi", when="@:13")
 
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
@@ -118,8 +118,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c~~mpi", when="+netcdf")
         with when("+berkeleygw"):
-            depends_on("berkeleygw@3:~~mpi", when="@:13")
-            depends_on("berkeleygw@2.1~~mpi", when="@14:")
+            depends_on("berkeleygw@3:~~mpi", when="@14:")
+            depends_on("berkeleygw@2.1~~mpi", when="@:13")
 
     depends_on("etsf-io", when="+etsf-io")
     depends_on("py-numpy", when="+python")

--- a/spack/package.py
+++ b/spack/package.py
@@ -101,7 +101,13 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("elpa+mpi", when="+elpa")
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c+mpi", when="+netcdf")
-        depends_on("berkeleygw@2.1+mpi", when="+berkeleygw")
+        with when("+berkeleygw")
+            # octopus dropped support for BerkeleyGW 2.1 in version 14
+            # only BerkeleyGW 3 is supported from version 14
+            # see https://gitlab.com/octopus-code/octopus/-/merge_requests/2257
+            # BerkeleyGW 2.1 is the last supported version until octopus@14
+            depends_on("berkeleygw@3:+mpi", when="@:13")
+            depends_on("berkeleygw@2.1+mpi", when="@14:")
 
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
@@ -111,7 +117,9 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("elpa~mpi", when="+elpa")
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c~~mpi", when="+netcdf")
-        depends_on("berkeleygw@2.1~mpi", when="+berkeleygw")
+        with when("+berkeleygw")
+            depends_on("berkeleygw@3:~~mpi", when="@:13")
+            depends_on("berkeleygw@2.1~~mpi", when="@14:")
 
     depends_on("etsf-io", when="+etsf-io")
     depends_on("py-numpy", when="+python")

--- a/spack/package.py
+++ b/spack/package.py
@@ -101,7 +101,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("elpa+mpi", when="+elpa")
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c+mpi", when="+netcdf")
-        with when("+berkeleygw")
+        with when("+berkeleygw"):
             # octopus dropped support for BerkeleyGW 2.1 in version 14
             # only BerkeleyGW 3 is supported from version 14
             # see https://gitlab.com/octopus-code/octopus/-/merge_requests/2257
@@ -117,7 +117,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("elpa~mpi", when="+elpa")
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c~~mpi", when="+netcdf")
-        with when("+berkeleygw")
+        with when("+berkeleygw"):
             depends_on("berkeleygw@3:~~mpi", when="@:13")
             depends_on("berkeleygw@2.1~~mpi", when="@14:")
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -102,8 +102,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
         depends_on("netcdf-fortran", when="+netcdf")
         depends_on("netcdf-c+mpi", when="+netcdf")
         with when("+berkeleygw"):
-            # octopus dropped support for BerkeleyGW 2.1 in version 14
-            # only BerkeleyGW 3 is supported from version 14
+            # From octopus@14:, upstream switched support from BerkeleyGW@2.1 to @3.0:
             # see https://gitlab.com/octopus-code/octopus/-/merge_requests/2257
             # BerkeleyGW 2.1 is the last supported version until octopus@14
             depends_on("berkeleygw@3:+mpi", when="@14:")


### PR DESCRIPTION
Octopus dropped support for BerkeleyGW 2.1 in version 14.
only BerkeleyGW 3 is supported from version 14 see https://gitlab.com/octopus-code/octopus/-/merge_requests/2257
Also note, that BerkeleyGW 2.1 is the last supported version until octopus@14.

This MR adds these constraints.