### PR TITLE
Update package for  octopus 14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bullseye
 # # but other strings can be given to the docker build command
 # # (for example docker build --build-arg SPACK_VERSION=v0.16.2)
 ARG SPACK_VERSION=develop
-ARG OCT_VERSION=13.0
+ARG OCT_VERSION=14.1
 ARG BERKELEYGW_VER=""
 RUN echo "Building with spack version ${SPACK_VERSION}"
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 # Using most recent spack version with preferred version of octopus
 spack-develop:
-	# Setting BERKELEYGW_VER to 3.0.1 as v4 is released but the download link is broken!
-	# This should be remoeved when the link is fixed as the versions for octopus stable should be infered by spack from the package.py file
+	# Setting BERKELEYGW_VER to 3.0.1 as v4 is released but its compatibility with octopus is not tested and the download link is broken!
+	# This should be removed when the link is fixed and the compatibility with berkeleygw version 4 is tested (octopus issue 1003)
+	# as the versions for octopus stable should be infered by spack from the package.py file and not here.
 	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg BERKELEYGW_VER="@3.0.1" -t octopus-spack  .
 
 # Using most recent spack version with most recent version of octopus

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 # Using most recent spack version with preferred version of octopus
 spack-develop:
-	docker build -f Dockerfile --build-arg SPACK_VERSION=develop -t octopus-spack  .
+	# Setting BERKELEYGW_VER to 3.0.1 as v4 is released but the download link is broken!
+	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg BERKELEYGW_VER="@3.0.1" -t octopus-spack  .
 
 # Using most recent spack version with most recent version of octopus
 spack-develop-octopus-develop:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Using most recent spack version with preferred version of octopus
 spack-develop:
 	# Setting BERKELEYGW_VER to 3.0.1 as v4 is released but the download link is broken!
+	# This should be remoeved when the link is fixed as the versions for octopus stable should be infered by spack from the package.py file
 	docker build -f Dockerfile --build-arg SPACK_VERSION=develop --build-arg BERKELEYGW_VER="@3.0.1" -t octopus-spack  .
 
 # Using most recent spack version with most recent version of octopus

--- a/spack/package.py
+++ b/spack/package.py
@@ -301,6 +301,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append(f"{cxxflags} {gcc10_extra}")
             args.append(f"{cflags} {gcc10_extra}")
 
+        # for octopus 14.1 and above autotools is deprecated in favour of cmake
+        # inorder to continue using autotools we pass `--enable-silent-deprecation`
+        if spec.satisfies("@14.1:"):
+            args.append("--enable-silent-deprecation")
+
         # Disable flags
         #
         # disable gdlib explicitly to avoid

--- a/spack/package.py
+++ b/spack/package.py
@@ -23,6 +23,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
     license("Apache-2.0")
 
+    version("14.1", sha256="6955f4020e69f038650a24509ff19ef35de4fd34e181539f92fa432db9b66ca7")
     version("14.0", sha256="3cf6ef571ff97cc2c226016815d2ac4aa1e00ae3fb0cc693e0aff5620b80373e")
     version("13.0", sha256="b4d0fd496c31a9c4aa4677360e631765049373131e61f396b00048235057aeb1")
     version("12.2", sha256="e919e07703696eadb4ba59352d7a2678a9191b4586cb9da538661615e765a5a2")


### PR DESCRIPTION
- add new version hash
- pass `--enable-silent-deprecation` to configure to allow use of autotools 