### PR TITLE
Modularize testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,55 +56,26 @@ RUN cd spack && git checkout $SPACK_VERSION
 # # show which version we use
 RUN $SPACK --version
 
-# copy our package.py into the spack tree (and also example files)
+# copy our package.py into the spack tree (and also example files and test scripts)
 COPY spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/octopus/package.py
 RUN ls -l $SPACK_ROOT/var/spack/repos/builtin/packages/octopus
 COPY spack/test/ $SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test
 RUN ls -l $SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test
+COPY spack_test_install.sh $SPACK_ROOT
 
 # Install and test serial and MPI versions of ocoptus via spack
 # # serial version
 
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
-      # create a new environment for the serial version and activate it:
-      spack env create octopus-serial && \
-      spack env activate octopus-serial && \
-      # display specs of upcoming spack installation:
+RUN  OCTOPUS_SPEC="octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BERKELEYGW_VER}" && \
       # we use the berkeleygw@3.0.1 as newer versions are not downloadable at the moment
       # see https://github.com/spack/spack/issues/43122
       # TODO: remove the version number when the issue is resolved
-      spack spec octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BERKELEYGW_VER} && \
-      # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} ~mpi+netcdf+arpack+cgal+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis ^berkeleygw${BERKELEYGW_VER} && \
-      spack install && \
-      # run spack smoke tests for octopus. We get an error if any of the fails:
-      spack test run --alias test_serial octopus && \
-      # display output from smoke tests (just for information):
-      spack test results -l test_serial && \
-      # show which octopus version we use (for convenience):
-      spack load octopus && octopus --version && \
-      # deactivate the environment.
-      spack env deactivate
+      source ${SPACK_ROOT}/spack_test_install.sh --spec ${OCTOPUS_SPEC} --spack-root ${SPACK_ROOT} --test-name octopus-serial
 
 # # MPI version
 
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
-      # create a new environment for the MPI version and activate it:
-      spack env create octopus-mpi && \
-      spack env activate octopus-mpi && \
-      # display specs of upcoming spack installation:
-      spack spec octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BERKELEYGW_VER}  && \
-      # run the spack installation (adding it to the environment):
-      spack add octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BERKELEYGW_VER} && \
-      spack install && \
-      # run spack smoke tests for octopus. We get an error if any of the fails:
-      spack test run --alias test_MPI octopus && \
-      # display output from smoke tests (just for information):
-      spack test results -l test_MPI && \
-      # show which octopus version we use (for convenience):
-      spack load octopus && octopus --version && \
-      # deactivate the environment.
-      spack env deactivate
+RUN OCTOPUS_SPEC="octopus@${OCT_VERSION} +mpi +netcdf+parmetis+arpack+cgal+pfft+pnfft+python+likwid+libyaml+elpa+nlopt+etsf-io+sparskit+berkeleygw+nfft~debug~cuda~metis~scalapack ^berkeleygw${BERKELEYGW_VER}"  && \
+      source ${SPACK_ROOT}/spack_test_install.sh --spec ${OCTOPUS_SPEC} --spack-root ${SPACK_ROOT} --test-name octopus-mpi
 
 # Provide bash in case the image is meant to be used interactively
 CMD /bin/bash -l

--- a/spack_test_install.sh
+++ b/spack_test_install.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Echo commands and exit on errors
+set -xe
+
+EXEC_DATE=$(date +%Y_%m_%d_%H_%M_%S)
+
+# Self documenting usage function
+function usage() {
+    echo "A bash script to install and test a spack \"spec\" of octopus package"
+    echo "Usage: $0 --spec SPEC_TO_TEST [--spack-root SPACK_ROOT] [--test-name TEST_NAME]"
+    echo "Where:"
+    echo "  --spec: The spack spec to test (eg octopus@14+mpi)"
+    echo "  --spack-root:(Optional) The spack root directory (eg /tmp/spack); if not specified, spack@develop will be cloned at /tmp/spack"
+    echo "  --test-name: (Optional) A name for the test and environment; defaults to \"Octopus_DATE\""
+    echo "Example: $0 --spec octopus@14+mpi --spack-root /tmp/spackv0.22.0"
+    echo "Example: $0 --spec octopus@14+mpi --test-name Octopus_mytest"
+    echo "Example: $0 --help"
+}
+
+# Capture the command line arguments
+# Test that at least one argument is provided
+if [[ $# -eq 0 || "$1" == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+# Parse the command line arguments
+SPEC_TO_TEST=""
+SPACK_ROOT=""
+TEST_NAME="Octopus_${EXEC_DATE}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --spec)
+            SPEC_TO_TEST="$2"
+            shift 2
+            ;;
+        --spack-root)
+            SPACK_ROOT="$2"
+            shift 2
+            ;;
+        --test-name)
+            TEST_NAME="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# cd into the spack root
+# If SPACK_ROOT is not specified, use spack@develop
+if [ -z "$SPACK_ROOT" ]; then
+    SPACK_ROOT="/tmp/spack"
+    pushd $SPACK_ROOT
+    git clone https://github.com/spack/spack.git .
+    git checkout develop
+else
+    pushd $SPACK_ROOT
+fi
+
+source share/spack/setup-env.sh
+
+# create a new environment and activate it
+spack env create $TEST_NAME
+spack env activate $TEST_NAME
+
+
+# display the specs of the upcoming spack installation
+spack spec $SPEC_TO_TEST
+# run the spack installation (adding it to the environment):
+spack add $SPEC_TO_TEST
+spack install
+
+# run spack smoke tests for octopus. We get an error if any of the fails:
+spack test run --alias $SPEC_TO_TEST octopus
+
+# display output from smoke tests (just for information):
+spack test results -l $SPEC_TO_TEST
+
+# show which octopus version we use (for convenience):
+spack load $SPEC_TO_TEST
+octopus --version
+
+# TODO: add more tests here ( eg. H atom)
+
+# deactivate the environment
+spack env deactivate


### PR DESCRIPTION
- Move the sourcing of spack, creating env, running the spec, installing the spec and testing it into a separate bash script
- allows using the `spack_test_install.sh`  multiple times for different specs ( for eg cmake, different compilers etc ) with less code duplication in the future
- allows using the `spack_test_install.sh` outside the repo for manual testing
- allows creation of a CI that tests the installation of the spack upstream package definition as well ( checks for eg when the download links fail or for changes in spack)